### PR TITLE
Fix cannot access role popup when role is correct

### DIFF
--- a/src/view/questionView/QuestionView.tsx
+++ b/src/view/questionView/QuestionView.tsx
@@ -272,6 +272,7 @@ const QuestionView: React.FC = () => {
                   for (const userRole of ModeratorAccess)
                     if (role === userRole) {
                       setDeletePopup(true);
+                      return;
                     }
                   setAlertModal(true);
                 }}


### PR DESCRIPTION
Add return to cancel popup when role is correct.